### PR TITLE
Avoid endless recursion in get_closest_ancestor_next_sibling

### DIFF
--- a/src/plugin/angular-tree-dnd-tree-control.js
+++ b/src/plugin/angular-tree-dnd-tree-control.js
@@ -215,7 +215,9 @@ angular.module('ntt.TreeDnD')
 
                     _parent = tree.get_parent(node);
                     if(_parent)
+                    {
                     	return tree.get_closest_ancestor_next_sibling(_parent);
+                    }
 
                     return null;
                 },

--- a/src/plugin/angular-tree-dnd-tree-control.js
+++ b/src/plugin/angular-tree-dnd-tree-control.js
@@ -214,7 +214,10 @@ angular.module('ntt.TreeDnD')
                     }
 
                     _parent = tree.get_parent(node);
-                    return tree.get_closest_ancestor_next_sibling(_parent);
+                    if(_parent)
+                    	return tree.get_closest_ancestor_next_sibling(_parent);
+
+                    return null;
                 },
                 get_next_node:                     function (node) {
                     node = node || tree.selected_node;


### PR DESCRIPTION
Fixed a bug in the get_closest_ancestor_next_sibling function which would recurse endlessly after the last node in the tree...
